### PR TITLE
change script to take path as argument

### DIFF
--- a/new_authors.sh
+++ b/new_authors.sh
@@ -1,8 +1,9 @@
 #!/bin/sh
 
 HERE=`pwd`
+PROJ_PATH="$1"
 
-cd /Users/john/Documents/swift/
+cd ${PROJ_PATH}
 git shortlog -nes >${HERE}/vcs_authors
 cd ${HERE}
-python ./authors.py ${HERE}/vcs_authors /Users/john/Documents/swift/AUTHORS
+python ./authors.py ${HERE}/vcs_authors ${PROJ_PATH}/AUTHORS


### PR DESCRIPTION
Works for any project that has AUTHORS file similar to Swift
(eg., liberasurecode, pyeclib)

Signed-off-by: Thiago da Silva <thiago@redhat.com>